### PR TITLE
別の環境で発生していたエラー修正を取り込み

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
           MYSQL_DATABASE: dbname_test
           MYSQL_USER: dbuser
-          MYSQL_PASSWORD: dbpass
+          MYSQL_PASSWORD: dbpassword
         options: --health-cmd "mysqladmin ping -h localhost" --health-interval 20s --health-timeout 10s --health-retries 10
 
     steps:

--- a/cake_app/config/.env.default
+++ b/cake_app/config/.env.default
@@ -11,6 +11,11 @@ export DATABASE_HOST="127.0.0.1"
 export DATABASE_NAME="dbname"
 export DATABASE_PORT="3306"
 export DATABASE_USER="dbuser"
-export DATABASE_PASS="dbpass"
+export DATABASE_PASS="dbpassword"
 
 export GOOGLEMAP_API_KEY=""
+
+#  PHPUnitテスト中など、エラーログがコンソール内に流れて見づらいときは以下の設定でファイルへのログを強制する
+# export LOG_DEBUG_URL="file://logs/?file=debug&path=/var/www/cake_app/logs/"
+# export LOG_ERROR_URL="file://logs/?file=error&path=/var/www/cake_app/logs/"
+# export LOG_QUERIES_URL="file://logs/?file=queries&path=/var/www/cake_app/logs/"

--- a/cake_app/src/Assets/scss/_admin_style.scss
+++ b/cake_app/src/Assets/scss/_admin_style.scss
@@ -326,7 +326,7 @@ body {
   /* ファイルキャプションとファイルプレビューについてfileinput.min.cssファイルの代わりにbootstrap-fileinput/scss/fileinput.scssをインポートした場合の表示崩れを修正する */
   .file-caption {
     .file-caption-name {
-      width: auto !important;
+      width: 0 !important;
       padding: $input-padding-y $input-padding-x !important;
       border: 1px solid $input-border-color;
     }
@@ -344,7 +344,6 @@ body {
         display: inline-block !important;
       }
       .file-caption-name {
-        width: 0 !important;
         padding-left: 1.875rem !important;
       }
       > .input-group-lg .file-caption-name {

--- a/cake_app/tests/TestCase/Controller/PagesControllerTest.php
+++ b/cake_app/tests/TestCase/Controller/PagesControllerTest.php
@@ -36,17 +36,10 @@ class PagesControllerTest extends TestCase
      */
     public function testMultipleGet()
     {
-        if (Configure::read('debug')) {
-            $this->get('/pages/home');
-            $this->assertResponseOk();
-            $this->get('/pages/home');
-            $this->assertResponseOk();
-        } else {
-            $this->get('/pages/home');
-            $this->assertResponseError();
-            $this->get('/pages/home');
-            $this->assertResponseError();
-        }
+        $this->get('/pages/home');
+        $this->assertResponseOk();
+        $this->get('/pages/home');
+        $this->assertResponseOk();
     }
 
     /**
@@ -56,16 +49,25 @@ class PagesControllerTest extends TestCase
      */
     public function testDisplay()
     {
+        Configure::write('debug', false);
         $this->get('/pages/home');
-        if (Configure::read('debug')) {
-            $this->assertResponseOk();
-            $this->assertResponseContains('CakePHP');
-            $this->assertResponseContains('<html>');
-        } else {
-            $this->assertResponseError();
-            $this->assertResponseContains('Please replace templates/Pages/home.php with your own version or re-enable debug mode.');
-            $this->assertResponseContains('<html>');
-        }
+        $this->assertResponseOk();
+        $this->assertResponseContains('Please be aware that this page will not be shown if you turn off debug mode unless you replace templates/Pages/home.php with your own version.');
+        $this->assertResponseContains('<html>');
+    }
+
+    /**
+     * testDisplay method in debug
+     *
+     * @return void
+     */
+    public function testDisplayInDebug()
+    {
+        Configure::write('debug', true);
+        $this->get('/pages/home');
+        $this->assertResponseOk();
+        $this->assertResponseContains('CakePHP');
+        $this->assertResponseContains('<html>');
     }
 
     /**
@@ -75,15 +77,25 @@ class PagesControllerTest extends TestCase
      */
     public function testMissingTemplate()
     {
+        Configure::write('debug', false);
         $this->get('/pages/not_existing');
-        if (Configure::read('debug')) {
-            $this->assertResponseContains('Missing Template');
-            $this->assertResponseContains('Stacktrace');
-            $this->assertResponseContains('not_existing.php');
-        } else {
-            $this->assertResponseError();
-            $this->assertResponseContains('Error');
-        }
+        $this->assertResponseFailure();
+        $this->assertResponseContains('Error');
+    }
+
+    /**
+     * Test that missing template in debug
+     *
+     * @return void
+     */
+    public function testMissingTemplateInDebug()
+    {
+        Configure::write('debug', true);
+        $this->get('/pages/not_existing');
+        $this->assertResponseFailure();
+        $this->assertResponseContains('Missing Template');
+        $this->assertResponseContains('Stacktrace');
+        $this->assertResponseContains('not_existing.php');
     }
 
     /**


### PR DESCRIPTION
.env.default
Docker環境を作成する際6文字のパスワードは拒否されてるので8文字以上の文字に修正

ci.yml
.env.defaultはGithubActionsのCIでも使われているため、パスワード部分を.env.defaultと同じ値で修正

PagesControllerTest.php
環境のデバッグモードのON、OFFに関わらず同じテストが行われるよう修正